### PR TITLE
Fix fallback for splitter class location.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
 		"class": "WP_CLI\\AutoloadSplitter\\ComposerPlugin"
 	},
 	"require": {
-		"composer-plugin-api": "^1.1"
+		"composer-plugin-api": "^1.1",
+		"mindplay/composer-locator": "^2.1"
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,59 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "ec9b119ba74dc86e614c457621048fc1",
+    "packages": [
+        {
+            "name": "mindplay/composer-locator",
+            "version": "2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mindplay-dk/composer-locator.git",
+                "reference": "aa49be073c3beb7185c4660eadb56cd3b144d16b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mindplay-dk/composer-locator/zipball/aa49be073c3beb7185c4660eadb56cd3b144d16b",
+                "reference": "aa49be073c3beb7185c4660eadb56cd3b144d16b",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1",
+                "php": ">= 5.4"
+            },
+            "require-dev": {
+                "composer/composer": "^1",
+                "mindplay/testies": "^0.3.0",
+                "symfony/filesystem": "^2.7 || ^3.0",
+                "symfony/process": "^2.7 || ^3.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "mindplay\\composer_locator\\Plugin"
+            },
+            "autoload": {
+                "classmap": [
+                    "src/ComposerLocator.php",
+                    "src/Plugin.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Locates Composer package root folders by package name",
+            "time": "2017-04-09T16:18:13+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/src/ComposerPlugin.php
+++ b/src/ComposerPlugin.php
@@ -8,6 +8,7 @@ use Composer\IO\IOInterface;
 use Composer\Plugin\PluginInterface;
 use Composer\Script\Event;
 use Composer\Script\ScriptEvents;
+use ComposerLocator;
 
 /**
  * Class ComposerPlugin.
@@ -65,8 +66,12 @@ final class ComposerPlugin implements PluginInterface, EventSubscriberInterface
             ->getPackage()
             ->getExtra();
 
+        $autoloadSplitterLocationFallback = ComposerLocator::isInstalled('wp-cli/wp-cli')
+            ? ComposerLocator::getPath('wp-cli/wp-cli') . '/php/WP_CLI/AutoloadSplitter.php'
+	        : 'vendor/wp-cli/wp-li/php/WP_CLI/AutoloadSplitter.php';
+
         $splitterLogic    = self::getExtraKey(self::LOGIC_CLASS_KEY, 'WP_CLI\AutoloadSplitter');
-        $splitterLocation = self::getExtraKey(self::LOGIC_CLASS_LOCATION_KEY, 'php/WP_CLI/AutoloadSplitter.php');
+        $splitterLocation = self::getExtraKey(self::LOGIC_CLASS_LOCATION_KEY, $autoloadSplitterLocationFallback);
         $filePrefixTrue   = self::getExtraKey(self::SPLIT_TARGET_PREFIX_TRUE_KEY, 'autoload_commands');
         $filePrefixFalse  = self::getExtraKey(self::SPLIT_TARGET_PREFIX_FALSE_KEY, 'autoload_framework');
 


### PR DESCRIPTION
Use `mindplay/composer-locator` to locate the root of the `wp-cli/wp-cli` package and make the path to the autoload splitter logic class depend on that location.

Fixes #1