### PR TITLE
Use vendor-dir from composer config

### DIFF
--- a/src/ComposerPlugin.php
+++ b/src/ComposerPlugin.php
@@ -3,6 +3,7 @@
 namespace WP_CLI\AutoloadSplitter;
 
 use Composer\Composer;
+use Composer\Config;
 use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\IO\IOInterface;
 use Composer\Plugin\PluginInterface;
@@ -59,19 +60,21 @@ final class ComposerPlugin implements PluginInterface, EventSubscriberInterface
         // iterated and translated to arrays of classes.
         $optimize = true;
 
-        $suffix = $config->get('autoloader-suffix');
+        $vendorDir       = $config->get('vendor-dir', Config::RELATIVE_PATHS);
+        $defaultLocation = "{$vendorDir}/wp-cli/wp-cli/php/WP_CLI/AutoloadSplitter.php";
+        $suffix          = $config->get('autoloader-suffix');
 
         self::$extra = $event->getComposer()
             ->getPackage()
             ->getExtra();
 
         $splitterLogic    = self::getExtraKey(self::LOGIC_CLASS_KEY, 'WP_CLI\AutoloadSplitter');
-        $splitterLocation = self::getExtraKey(self::LOGIC_CLASS_LOCATION_KEY, 'vendor/wp-cli/wp-cli/php/WP_CLI/AutoloadSplitter.php');
+        $splitterLocation = self::getExtraKey(self::LOGIC_CLASS_LOCATION_KEY, $defaultLocation);
         $filePrefixTrue   = self::getExtraKey(self::SPLIT_TARGET_PREFIX_TRUE_KEY, 'autoload_commands');
         $filePrefixFalse  = self::getExtraKey(self::SPLIT_TARGET_PREFIX_FALSE_KEY, 'autoload_framework');
 
-        if (! class_exists($splitterLogic)) {
-            include_once getcwd() . "/{$splitterLocation}";
+        if (!class_exists($splitterLogic)) {
+            include_once sprintf('%s/%s', getcwd(), $splitterLocation);
         }
 
         $generator = new AutoloadGenerator(


### PR DESCRIPTION
Related to #5.

I have a project with a custom setting for `vendor-dir`. In attempting to include `wp-cli/wp-cli` as a dependency, I was getting the following error from this repo:

```
[ErrorException]
include_once(/<path>/vendor/wp-cli/wp-cli/php/WP_CLI/AutoloadSplitter.php): failed to open stream: No such file or directory
```

I was able to resolve the error with the following config setting:

```
    "extra": {
        "autoload-splitter": {
            "splitter-location": "<custom directory>/wp-cli/wp-cli/php/WP_CLI/AutoloadSplitter.php"
        }
    }
```

While this works, I think that the fallback for the AutoloadSplitter location should use the configured `vendor-dir` setting for Composer, rather than the hardcoded `vendor/` directory. While it is currently possible to override the hardcoded option with a config `extra` value, this shouldn't be necessary for a custom vendor directory.

This PR updates the `WP_CLI\AutoloadSplitter\ComposerPlugin` class to properly account for the configured `vendor-dir` from Composer.